### PR TITLE
Reduced phantom membrane drop rates, Adjusted and added some missing attributes.

### DIFF
--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/AbstractLatexSquidDog.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/AbstractLatexSquidDog.java
@@ -39,7 +39,7 @@ public abstract class AbstractLatexSquidDog extends AbstractAquaticEntity implem
     protected void setAttributes(AttributeMap attributes) {
         super.setAttributes(attributes);
         attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.0925);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.1);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.2);
         attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(30.0);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/AbstractLightLatexWolf.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/AbstractLightLatexWolf.java
@@ -1,16 +1,20 @@
 package net.ltxprogrammer.changed.entity.beast;
 
-import net.ltxprogrammer.changed.entity.ChangedEntity;
-import net.ltxprogrammer.changed.entity.GenderedEntity;
-import net.ltxprogrammer.changed.entity.LatexType;
-import net.ltxprogrammer.changed.entity.TransfurCause;
+import net.ltxprogrammer.changed.entity.*;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.level.Level;
 
 public abstract class AbstractLightLatexWolf extends ChangedEntity implements GenderedEntity {
     public AbstractLightLatexWolf(EntityType<? extends AbstractLightLatexWolf> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.wolfLike(attributes);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/AbstractSnowLeopard.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/AbstractSnowLeopard.java
@@ -5,7 +5,9 @@ import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeMap;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ForgeMod;
 
 public abstract class AbstractSnowLeopard extends ChangedEntity implements GenderedEntity, PowderSnowWalkable {
     public AbstractSnowLeopard(EntityType<? extends AbstractSnowLeopard> p_19870_, Level p_19871_) {
@@ -38,6 +40,9 @@ public abstract class AbstractSnowLeopard extends ChangedEntity implements Gende
     @Override
     protected void setAttributes(AttributeMap attributes) {
         super.setAttributes(attributes);
-        AttributePresets.catLike(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.12f);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.9);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(22.0);
     }
+
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/AbstractWhiteWolf.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/AbstractWhiteWolf.java
@@ -1,9 +1,11 @@
 package net.ltxprogrammer.changed.entity.beast;
 
+import net.ltxprogrammer.changed.entity.AttributePresets;
 import net.ltxprogrammer.changed.entity.GenderedEntity;
 import net.ltxprogrammer.changed.entity.HairStyle;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +14,12 @@ import java.util.List;
 public abstract class AbstractWhiteWolf extends AbstractLatexWolf implements GenderedEntity {
     public AbstractWhiteWolf(EntityType<? extends AbstractWhiteWolf> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.wolfLike(attributes);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/DarkLatexDragon.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/DarkLatexDragon.java
@@ -3,6 +3,7 @@ package net.ltxprogrammer.changed.entity.beast;
 import net.ltxprogrammer.changed.entity.*;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -15,6 +16,12 @@ public class DarkLatexDragon extends ChangedEntity implements DarkLatexEntity, P
 
     public boolean isMaskless() {
         return true;
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.dragonLike(attributes);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/DarkLatexYufeng.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/DarkLatexYufeng.java
@@ -17,6 +17,12 @@ public class DarkLatexYufeng extends AbstractDarkLatexEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.dragonLike(attributes);
+    }
+
+    @Override
     public HairStyle getDefaultHairStyle() {
         return HairStyle.BALD.get();
     }
@@ -38,11 +44,5 @@ public class DarkLatexYufeng extends AbstractDarkLatexEntity {
     @Override
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.fromInt(0x3d3d3d);
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        AttributePresets.dragonLike(attributes);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/GasWolf.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/GasWolf.java
@@ -1,8 +1,10 @@
 package net.ltxprogrammer.changed.entity.beast;
 
+import net.ltxprogrammer.changed.entity.AttributePresets;
 import net.ltxprogrammer.changed.entity.HairStyle;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -11,6 +13,12 @@ import java.util.List;
 public class GasWolf extends AbstractLatexWolf {
     public GasWolf(EntityType<? extends GasWolf> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.wolfLike(attributes);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/GreenLizard.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/GreenLizard.java
@@ -23,7 +23,7 @@ public class GreenLizard extends ChangedEntity {
     protected void setAttributes(AttributeMap attributes) {
         super.setAttributes(attributes);
         attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.98);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.0);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/GreenLizard.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/GreenLizard.java
@@ -20,6 +20,13 @@ public class GreenLizard extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.98);
+    }
+
+    @Override
     public LatexType getLatexType() {
         return LatexType.NEUTRAL;
     }
@@ -41,12 +48,5 @@ public class GreenLizard extends ChangedEntity {
 
     public @Nullable List<HairStyle> getValidHairStyles() {
         return HairStyle.Collection.EMPTY;
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.1075);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.98);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/HeadlessKnight.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/HeadlessKnight.java
@@ -15,6 +15,7 @@ import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ForgeMod;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -22,6 +23,14 @@ import java.util.List;
 public class HeadlessKnight extends WhiteLatexKnight implements LatexTaur<HeadlessKnight> {
     public HeadlessKnight(EntityType<? extends HeadlessKnight> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.FOLLOW_RANGE).setBaseValue(8.0);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.115);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.9);
     }
 
     @Override
@@ -90,11 +99,5 @@ public class HeadlessKnight extends WhiteLatexKnight implements LatexTaur<Headle
 
     public @Nullable List<HairStyle> getValidHairStyles() {
         return HairStyle.Collection.EMPTY;
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.FOLLOW_RANGE).setBaseValue(8.0);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexAlien.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexAlien.java
@@ -18,6 +18,13 @@ public class LatexAlien extends ChangedEntity {
         super(p_19870_, p_19871_);
     }
 
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.1);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.0);
+    }
+
     public Color3 getDripColor() {
         return Color3.getColor("#1983a9");
     }
@@ -48,12 +55,5 @@ public class LatexAlien extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#1983a9");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.1);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.0);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexBee.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexBee.java
@@ -21,6 +21,13 @@ public class LatexBee extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.75);
+    }
+
+    @Override
     public int getTicksRequiredToFreeze() { return 240; }
 
     @Override
@@ -53,12 +60,5 @@ public class LatexBee extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#fdbf77");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.75);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexBeifeng.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexBeifeng.java
@@ -19,6 +19,13 @@ public class LatexBeifeng extends AbstractLatexWolf implements DarkLatexEntity, 
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.0);
+    }
+
+    @Override
     public Color3 getDripColor() {
         return level.random.nextInt(10) > 3 ? Color3.BLUE : Color3.WHITE;
     }
@@ -39,12 +46,5 @@ public class LatexBeifeng extends AbstractLatexWolf implements DarkLatexEntity, 
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#51659d");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.0);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexBenignWolf.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexBenignWolf.java
@@ -19,6 +19,14 @@ public class LatexBenignWolf extends AbstractLatexWolf {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.FOLLOW_RANGE).setBaseValue(4.0);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.015);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.2);
+    }
+
+    @Override
     public TransfurMode getTransfurMode() {
         return TransfurMode.ABSORPTION;
     }
@@ -43,13 +51,5 @@ public class LatexBenignWolf extends AbstractLatexWolf {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#282828");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.FOLLOW_RANGE).setBaseValue(4.0);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.015);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.15);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexBlueDragon.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexBlueDragon.java
@@ -17,6 +17,13 @@ public class LatexBlueDragon extends ChangedEntity implements PowderSnowWalkable
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.0);
+    }
+
+    @Override
     public int getTicksRequiredToFreeze() { return 480; }
 
     @Override
@@ -45,12 +52,5 @@ public class LatexBlueDragon extends ChangedEntity implements PowderSnowWalkable
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#eef9ff");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.98);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexBlueWolf.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexBlueWolf.java
@@ -3,6 +3,7 @@ package net.ltxprogrammer.changed.entity.beast;
 import net.ltxprogrammer.changed.entity.*;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -11,6 +12,12 @@ import java.util.List;
 public class LatexBlueWolf extends AbstractLightLatexWolf implements PowderSnowWalkable {
     public LatexBlueWolf(EntityType<? extends LatexBlueWolf> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.wolfLike(attributes);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexCrocodile.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexCrocodile.java
@@ -17,6 +17,14 @@ public class LatexCrocodile extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.0925);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.1);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(32);
+    }
+
+    @Override
     public LatexType getLatexType() {
         return LatexType.NEUTRAL;
     }
@@ -47,13 +55,5 @@ public class LatexCrocodile extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#2b86a3");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.0925);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.1);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(32);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexCrystalWolf.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexCrystalWolf.java
@@ -1,9 +1,11 @@
 package net.ltxprogrammer.changed.entity.beast;
 
+import net.ltxprogrammer.changed.entity.AttributePresets;
 import net.ltxprogrammer.changed.entity.HairStyle;
 import net.ltxprogrammer.changed.entity.TransfurCause;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +14,12 @@ import java.util.List;
 public class LatexCrystalWolf extends AbstractLatexWolf implements DarkLatexEntity {
     public LatexCrystalWolf(EntityType<? extends AbstractLatexWolf> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.wolfLike(attributes);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexCrystalWolfHorned.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexCrystalWolfHorned.java
@@ -1,9 +1,11 @@
 package net.ltxprogrammer.changed.entity.beast;
 
+import net.ltxprogrammer.changed.entity.AttributePresets;
 import net.ltxprogrammer.changed.entity.HairStyle;
 import net.ltxprogrammer.changed.entity.TransfurCause;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +14,12 @@ import java.util.List;
 public class LatexCrystalWolfHorned extends AbstractLatexWolf implements DarkLatexEntity {
     public LatexCrystalWolfHorned(EntityType<? extends AbstractLatexWolf> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.wolfLike(attributes);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexDeer.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexDeer.java
@@ -19,6 +19,13 @@ public class LatexDeer extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.11);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
+    }
+
+    @Override
     public Color3 getDripColor() {
         return Color3.getColor(this.random.nextInt(4) < 3 ? "#d8bc99" : "#fbe5bc");
     }
@@ -49,12 +56,5 @@ public class LatexDeer extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#d8bc99");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.11);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexFennecFox.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexFennecFox.java
@@ -3,11 +3,21 @@ package net.ltxprogrammer.changed.entity.beast;
 import net.ltxprogrammer.changed.entity.TransfurMode;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ForgeMod;
 
 public class LatexFennecFox extends AbstractLatexWolf {
     public LatexFennecFox(EntityType<? extends LatexFennecFox> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.11);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.93);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexHypnoCat.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexHypnoCat.java
@@ -6,6 +6,7 @@ import net.ltxprogrammer.changed.entity.*;
 import net.ltxprogrammer.changed.init.ChangedAbilities;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,6 +14,12 @@ import java.util.List;
 
 public class LatexHypnoCat extends AbstractLatexHypnoCat implements PatronOC {
     protected final SimpleAbilityInstance hypnosis;
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.catLike(attributes);
+    }
 
     public LatexHypnoCat(EntityType<? extends LatexHypnoCat> type, Level level) {
         super(type, level);

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexKeonWolf.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexKeonWolf.java
@@ -1,10 +1,12 @@
 package net.ltxprogrammer.changed.entity.beast;
 
+import net.ltxprogrammer.changed.entity.AttributePresets;
 import net.ltxprogrammer.changed.entity.HairStyle;
 import net.ltxprogrammer.changed.entity.PatronOC;
 import net.ltxprogrammer.changed.entity.TransfurCause;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -14,6 +16,13 @@ public class LatexKeonWolf extends AbstractLatexWolf implements PatronOC {
     public LatexKeonWolf(EntityType<? extends LatexKeonWolf> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
     }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.wolfLike(attributes);
+    }
+
     @Override
     public Color3 getDripColor() {
         return Color3.SILVER;

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexLeaf.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexLeaf.java
@@ -17,6 +17,13 @@ public class LatexLeaf extends ChangedEntity implements PatronOC {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
+    }
+
+    @Override
     public LatexType getLatexType() {
         return LatexType.NEUTRAL;
     }
@@ -42,12 +49,5 @@ public class LatexLeaf extends ChangedEntity implements PatronOC {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#bff198");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.1075);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMantaRayFemale.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMantaRayFemale.java
@@ -21,6 +21,14 @@ public class LatexMantaRayFemale extends AbstractLatexMantaRay {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.034);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.9);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28);
+    }
+
+    @Override
     public Gender getGender() {
         return Gender.FEMALE;
     }
@@ -44,13 +52,5 @@ public class LatexMantaRayFemale extends AbstractLatexMantaRay {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#6f7696");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.026);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.9);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMedusaCat.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMedusaCat.java
@@ -16,6 +16,11 @@ public class LatexMedusaCat extends ChangedEntity {
         super(p_19870_, p_19871_);
     }
 
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.catLike(attributes);
+    }
 
     @Override
     public Color3 getDripColor() {
@@ -44,11 +49,5 @@ public class LatexMedusaCat extends ChangedEntity {
     @Override
     public TransfurMode getTransfurMode() {
         return TransfurMode.ABSORPTION;
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        AttributePresets.catLike(attributes);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMermaidShark.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMermaidShark.java
@@ -16,6 +16,15 @@ public class LatexMermaidShark extends AbstractAquaticGenderedEntity {
     public LatexMermaidShark(EntityType<? extends LatexMermaidShark> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
     }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.034);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.9);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28);
+    }
+
     @Override
     public Gender getGender() {
         return Gender.MALE;
@@ -54,13 +63,5 @@ public class LatexMermaidShark extends AbstractAquaticGenderedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#969696");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.026);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.9);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMimicPlant.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMimicPlant.java
@@ -19,6 +19,13 @@ public class LatexMimicPlant extends LatexLeaf {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
+    }
+
+    @Override
     public TransfurMode getTransfurMode() {
         return TransfurMode.ABSORPTION;
     }
@@ -44,12 +51,5 @@ public class LatexMimicPlant extends LatexLeaf {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#497469");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMingCat.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMingCat.java
@@ -16,6 +16,11 @@ public class LatexMingCat extends ChangedEntity implements PatronOC {
         super(p_19870_, p_19871_);
     }
 
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.catLike(attributes);
+    }
 
     @Override
     public Color3 getDripColor() {
@@ -48,11 +53,5 @@ public class LatexMingCat extends ChangedEntity implements PatronOC {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#d2a87f");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        AttributePresets.catLike(attributes);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMoth.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMoth.java
@@ -17,6 +17,13 @@ public class LatexMoth extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.75);
+    }
+
+    @Override
     public int getTicksRequiredToFreeze() { return 240; }
 
     @Override
@@ -49,12 +56,5 @@ public class LatexMoth extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#d8bc99");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.75);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMutantBloodcellWolf.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexMutantBloodcellWolf.java
@@ -13,14 +13,14 @@ public class LatexMutantBloodcellWolf extends WhiteLatexEntity {
     }
 
     @Override
-    public TransfurMode getTransfurMode() {
-        return TransfurMode.ABSORPTION;
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.1);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.9);
     }
 
     @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.9);
+    public TransfurMode getTransfurMode() {
+        return TransfurMode.ABSORPTION;
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexOrca.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexOrca.java
@@ -18,6 +18,13 @@ public class LatexOrca extends AbstractAquaticEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.0875);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.3);
+    }
+
+    @Override
     public Color3 getDripColor() {
         return level.random.nextInt(10) > 3 ? Color3.DARK : Color3.WHITE;
     }
@@ -38,12 +45,5 @@ public class LatexOrca extends AbstractAquaticEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#393939");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.0875);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.3);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexOtter.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexOtter.java
@@ -17,6 +17,13 @@ public class LatexOtter extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.2);
+    }
+
+    @Override
     public LatexType getLatexType() {
         return LatexType.NEUTRAL;
     }
@@ -47,12 +54,5 @@ public class LatexOtter extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#5d4743");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.2);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexPinkDeer.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexPinkDeer.java
@@ -8,7 +8,9 @@ import net.ltxprogrammer.changed.entity.TransfurMode;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeMap;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ForgeMod;
 
 
 public class LatexPinkDeer extends LatexPinkWyvern {
@@ -16,6 +18,12 @@ public class LatexPinkDeer extends LatexPinkWyvern {
         super(p_19870_, p_19871_);
     }
 
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.1075);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
+    }
 
     @Override
     public Color3 getDripColor() {
@@ -40,11 +48,5 @@ public class LatexPinkDeer extends LatexPinkWyvern {
             return Color3.fromInt(0xd8bc99);
         else
             return Color3.fromInt(0xf7aebe);
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        AttributePresets.wolfLike(attributes);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexPinkWyvern.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexPinkWyvern.java
@@ -18,6 +18,13 @@ public class LatexPinkWyvern extends ChangedEntity implements PowderSnowWalkable
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
+    }
+
+    @Override
     public Color3 getDripColor() {
         return Color3.getColor(this.random.nextInt(4) < 3 ? "#f7aebe" : "#ffffff");
     }
@@ -48,13 +55,6 @@ public class LatexPinkWyvern extends ChangedEntity implements PowderSnowWalkable
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#f7aebe");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
     }
 }
 

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexPinkYuinDragon.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexPinkYuinDragon.java
@@ -14,6 +14,12 @@ public class LatexPinkYuinDragon extends LatexPinkWyvern implements PowderSnowWa
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.dragonLike(attributes);
+    }
+
+    @Override
     public Color3 getDripColor() {
         return Color3.getColor(this.random.nextInt(4) < 3 ? "#f2aaba" : "#d1626d");
     }
@@ -34,11 +40,5 @@ public class LatexPinkYuinDragon extends LatexPinkWyvern implements PowderSnowWa
             return Color3.WHITE;
         else
             return Color3.fromInt(0xf7aebe);
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        AttributePresets.dragonLike(attributes);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexPurpleFox.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexPurpleFox.java
@@ -1,16 +1,23 @@
 package net.ltxprogrammer.changed.entity.beast;
 
-import net.ltxprogrammer.changed.entity.HairStyle;
-import net.ltxprogrammer.changed.entity.PatronOC;
-import net.ltxprogrammer.changed.entity.PowderSnowWalkable;
-import net.ltxprogrammer.changed.entity.TransfurCause;
+import net.ltxprogrammer.changed.entity.*;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ForgeMod;
 
 public class LatexPurpleFox extends AbstractLatexWolf implements PowderSnowWalkable, PatronOC {
     public LatexPurpleFox(EntityType<? extends LatexPurpleFox> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.11);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.93);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexRaccoon.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexRaccoon.java
@@ -18,6 +18,13 @@ public class LatexRaccoon extends ChangedEntity {
         super(p_19870_, p_19871_);
     }
 
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.FOLLOW_RANGE).setBaseValue(8.0);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.095);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.97);
+    }
 
     @Override
     public Color3 getDripColor() {
@@ -50,13 +57,5 @@ public class LatexRaccoon extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#949494");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.FOLLOW_RANGE).setBaseValue(8.0);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.095);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.97);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexRedDragon.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexRedDragon.java
@@ -16,6 +16,11 @@ public class LatexRedDragon extends ChangedEntity implements PatronOC {
         super(p_19870_, p_19871_);
     }
 
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.dragonLike(attributes);
+    }
 
     @Override
     public Color3 getDripColor() {
@@ -46,11 +51,5 @@ public class LatexRedDragon extends ChangedEntity implements PatronOC {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#d496a2");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        AttributePresets.dragonLike(attributes);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexRedPanda.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexRedPanda.java
@@ -18,6 +18,12 @@ public class LatexRedPanda extends ChangedEntity {
         super(p_19870_, p_19871_);
     }
 
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
+    }
 
     @Override
     public Color3 getDripColor() {
@@ -51,12 +57,5 @@ public class LatexRedPanda extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#bd4040");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSharkFemale.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSharkFemale.java
@@ -19,6 +19,14 @@ public class LatexSharkFemale extends AbstractLatexShark implements GenderedEnti
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.09);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.35);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28);
+    }
+
+    @Override
     public TransfurMode getTransfurMode() {
         return TransfurMode.ABSORPTION;
     }
@@ -35,13 +43,5 @@ public class LatexSharkFemale extends AbstractLatexShark implements GenderedEnti
     @Override
     public Gender getGender() {
         return Gender.FEMALE;
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.09);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.35);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSharkMale.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSharkMale.java
@@ -19,6 +19,14 @@ public class LatexSharkMale extends AbstractLatexShark implements GenderedEntity
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.09);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.35);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28);
+    }
+
+    @Override
     public HairStyle getDefaultHairStyle() {
         return HairStyle.BALD.get();
     }
@@ -35,13 +43,5 @@ public class LatexSharkMale extends AbstractLatexShark implements GenderedEntity
     @Override
     public Gender getGender() {
         return Gender.MALE;
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.09);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.35);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSiren.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSiren.java
@@ -27,6 +27,14 @@ public class LatexSiren extends AbstractAquaticGenderedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.034);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.9);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28);
+    }
+
+    @Override
     public Gender getGender() {
         return Gender.FEMALE;
     }
@@ -64,13 +72,5 @@ public class LatexSiren extends AbstractAquaticGenderedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#969696");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.026);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.9);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSnake.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSnake.java
@@ -20,6 +20,14 @@ public class LatexSnake extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.1);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(26);
+    }
+
+    @Override
     public LatexType getLatexType() {
         return LatexType.NEUTRAL;
     }
@@ -51,13 +59,5 @@ public class LatexSnake extends ChangedEntity {
     @Override
     public boolean isMovingSlowly() {
         return this.isCrouching();
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.1);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(26);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSniperDog.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSniperDog.java
@@ -1,10 +1,12 @@
 package net.ltxprogrammer.changed.entity.beast;
 
+import net.ltxprogrammer.changed.entity.AttributePresets;
 import net.ltxprogrammer.changed.entity.HairStyle;
 import net.ltxprogrammer.changed.entity.LatexType;
 import net.ltxprogrammer.changed.entity.TransfurCause;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,6 +15,12 @@ import java.util.List;
 public class LatexSniperDog extends AbstractLatexWolf {
     public LatexSniperDog(EntityType<? extends LatexSniperDog> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.wolfLike(attributes);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSnowLeopardMale.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSnowLeopardMale.java
@@ -17,11 +17,6 @@ public class LatexSnowLeopardMale extends AbstractSnowLeopard {
         super(p_19870_, p_19871_);
     }
 
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(1.2f);
-    }
-
     @Override
     public HairStyle getDefaultHairStyle() {
         return HairStyle.BALD.get();

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSquirrel.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexSquirrel.java
@@ -17,6 +17,13 @@ public class LatexSquirrel extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.11);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.9);
+    }
+
+    @Override
     public TransfurMode getTransfurMode() {
         return TransfurMode.REPLICATION;
     }
@@ -47,12 +54,5 @@ public class LatexSquirrel extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#ac8e63");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.11);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.9);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexStiger.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexStiger.java
@@ -7,10 +7,13 @@ import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.ForgeMod;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -19,6 +22,13 @@ public class LatexStiger extends ChangedEntity {
     private static final EntityDataAccessor<Byte> DATA_FLAGS_ID = SynchedEntityData.defineId(LatexStiger.class, EntityDataSerializers.BYTE);
     public LatexStiger(EntityType<? extends LatexStiger> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.1);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexTigerShark.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexTigerShark.java
@@ -23,6 +23,14 @@ public class LatexTigerShark extends AbstractAquaticEntity {
         summonSharks = registerAbility(ability -> this.wantToSummon(), new SimpleAbilityInstance(ChangedAbilities.SUMMON_SHARKS.get(), IAbstractChangedEntity.forEntity(this)));
     }
 
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.0925);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.15);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28.0);
+    }
+
     public boolean wantToSummon() {
         return getTarget() != null;
     }
@@ -43,13 +51,5 @@ public class LatexTigerShark extends AbstractAquaticEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#969696");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.0925);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.2);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28.0);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexTrafficConeDragon.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexTrafficConeDragon.java
@@ -17,6 +17,13 @@ public class LatexTrafficConeDragon extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
+    }
+
+    @Override
     public LatexType getLatexType() {
         return LatexType.NEUTRAL;
     }
@@ -47,12 +54,5 @@ public class LatexTrafficConeDragon extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#ffd201");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexTranslucentLizard.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexTranslucentLizard.java
@@ -17,6 +17,13 @@ public class LatexTranslucentLizard extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.0);
+    }
+
+    @Override
     public LatexType getLatexType() {
         return LatexType.NEUTRAL;
     }
@@ -47,12 +54,5 @@ public class LatexTranslucentLizard extends ChangedEntity {
 
     public Color3 getTransfurColor(TransfurCause cause) {
         return Color3.getColor("#ffb84b");
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(1.0);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexWhiteTiger.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexWhiteTiger.java
@@ -16,6 +16,11 @@ public class LatexWhiteTiger extends ChangedEntity implements PowderSnowWalkable
         super(p_19870_, p_19871_);
     }
 
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.catLike(attributes);
+    }
 
     @Override
     public Color3 getDripColor() {
@@ -44,11 +49,5 @@ public class LatexWhiteTiger extends ChangedEntity implements PowderSnowWalkable
     @Override
     public Color3 getHairColor(int layer) {
         return Color3.WHITE;
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        AttributePresets.catLike(attributes);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexYuin.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/LatexYuin.java
@@ -18,6 +18,12 @@ public class LatexYuin extends ChangedEntity implements PowderSnowWalkable, Patr
         super(p_19870_, p_19871_);
     }
 
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
+    }
 
     @Override
     public Color3 getDripColor() {
@@ -42,12 +48,5 @@ public class LatexYuin extends ChangedEntity implements PowderSnowWalkable, Patr
 
     public @Nullable List<HairStyle> getValidHairStyles() {
         return HairStyle.Collection.EMPTY;
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.98);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/MilkPudding.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/MilkPudding.java
@@ -29,6 +29,15 @@ public class MilkPudding extends ChangedEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(8.0);
+        attributes.getInstance(Attributes.FOLLOW_RANGE).setBaseValue(12.0);
+        attributes.getInstance(Attributes.ATTACK_DAMAGE).setBaseValue(2.0D);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.09);
+    }
+
+    @Override
     public LatexType getLatexType() {
         return LatexType.NEUTRAL;
     }
@@ -56,12 +65,5 @@ public class MilkPudding extends ChangedEntity {
     @Override
     public Color3 getHairColor(int layer) {
         return Color3.WHITE;
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(8.0);
-        attributes.getInstance(Attributes.FOLLOW_RANGE).setBaseValue(12.0);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/PureWhiteLatexWolf.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/PureWhiteLatexWolf.java
@@ -16,7 +16,7 @@ public class PureWhiteLatexWolf extends WhiteLatexEntity {
     @Override
     protected void setAttributes(AttributeMap attributes) {
         super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.105);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.095);
         attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.9);
     }
 

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/Shark.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/Shark.java
@@ -28,6 +28,15 @@ public class Shark extends AbstractAquaticEntity {
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(10.0D);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(1.2D);
+        attributes.getInstance(Attributes.ATTACK_DAMAGE).setBaseValue(3.0D);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(2.4D);
+    }
+
+    @Override
     public TransfurMode getTransfurMode() {
         return TransfurMode.ABSORPTION;
     }
@@ -40,15 +49,6 @@ public class Shark extends AbstractAquaticEntity {
     @Override
     public TransfurVariant<?> getTransfurVariant() {
         return this.level.getSeaLevel() - 6 > this.getBlockY() ? ChangedTransfurVariants.Gendered.LATEX_MERMAID_SHARKS.getRandomVariant(this.random) : ChangedTransfurVariants.LATEX_SHARK.get();
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(10.0D);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(1.2D);
-        attributes.getInstance(Attributes.ATTACK_DAMAGE).setBaseValue(3.0D);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(2.9D);
     }
 
     protected PathNavigation createNavigation(Level p_28362_) {

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/WhiteLatexCentaur.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/WhiteLatexCentaur.java
@@ -23,6 +23,14 @@ public class WhiteLatexCentaur extends WhiteLatexKnight implements LatexTaur<Whi
     }
 
     @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.12);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.9);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(30);
+    }
+
+    @Override
     public LatexType getLatexType() {
         return LatexType.NEUTRAL;
     }
@@ -86,13 +94,5 @@ public class WhiteLatexCentaur extends WhiteLatexKnight implements LatexTaur<Whi
     @Override
     public boolean isAllowedToSwim() {
         return true;
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.12);
-        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.9);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(30);
     }
 }

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/WhiteLatexKnight.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/WhiteLatexKnight.java
@@ -1,5 +1,6 @@
 package net.ltxprogrammer.changed.entity.beast;
 
+import net.ltxprogrammer.changed.entity.AttributePresets;
 import net.ltxprogrammer.changed.entity.HairStyle;
 import net.ltxprogrammer.changed.entity.LatexType;
 import net.ltxprogrammer.changed.entity.TransfurMode;
@@ -7,7 +8,10 @@ import net.ltxprogrammer.changed.entity.variant.TransfurVariant;
 import net.ltxprogrammer.changed.init.ChangedTransfurVariants;
 import net.ltxprogrammer.changed.util.Color3;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ForgeMod;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -15,6 +19,12 @@ import java.util.List;
 public class WhiteLatexKnight extends AbstractLatexWolf {
     public WhiteLatexKnight(EntityType<? extends WhiteLatexKnight> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        AttributePresets.wolfLike(attributes);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/entity/beast/WhiteLatexKnightFusion.java
+++ b/src/main/java/net/ltxprogrammer/changed/entity/beast/WhiteLatexKnightFusion.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ForgeMod;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -17,6 +18,14 @@ import java.util.List;
 public class WhiteLatexKnightFusion extends WhiteLatexKnight {
     public WhiteLatexKnightFusion(EntityType<? extends WhiteLatexKnightFusion> p_19870_, Level p_19871_) {
         super(p_19870_, p_19871_);
+    }
+
+    @Override
+    protected void setAttributes(AttributeMap attributes) {
+        super.setAttributes(attributes);
+        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28.0);
+        attributes.getInstance(Attributes.MOVEMENT_SPEED).setBaseValue(0.1075f);
+        attributes.getInstance(ForgeMod.SWIM_SPEED.get()).setBaseValue(0.95);
     }
 
     @Override
@@ -51,11 +60,5 @@ public class WhiteLatexKnightFusion extends WhiteLatexKnight {
     @Override
     public TransfurVariant<?> getTransfurVariant() {
         return ChangedTransfurVariants.WHITE_LATEX_KNIGHT_FUSION.get();
-    }
-
-    @Override
-    protected void setAttributes(AttributeMap attributes) {
-        super.setAttributes(attributes);
-        attributes.getInstance(Attributes.MAX_HEALTH).setBaseValue(28.0);
     }
 }

--- a/src/main/resources/data/changed/advancements/recipes/changed_items/black_dye_from_latex_inkball.json
+++ b/src/main/resources/data/changed/advancements/recipes/changed_items/black_dye_from_latex_inkball.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:black_dye"
+    ]
+  },
+  "criteria": {
+    "has_latex_inkball": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "changed:latex_inkball"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:black_dye"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_latex_inkball",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/changed/loot_tables/entities/dark_latex_dragon.json
+++ b/src/main/resources/data/changed/loot_tables/entities/dark_latex_dragon.json
@@ -26,7 +26,27 @@
               }
             }
           ],
+          "name": "minecraft:black_dye"
+        }
+      ]
+    },
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
           "name": "minecraft:phantom_membrane"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0.15,
+          "looting_multiplier": 0.02
         }
       ]
     },

--- a/src/main/resources/data/changed/loot_tables/entities/dark_latex_yufeng.json
+++ b/src/main/resources/data/changed/loot_tables/entities/dark_latex_yufeng.json
@@ -65,26 +65,17 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 0.0,
-                "max": 2.0
-              },
-              "add": false
-            },
-            {
-              "function": "minecraft:looting_enchant",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 0.0,
-                "max": 1.0
-              }
-            }
-          ],
           "name": "minecraft:phantom_membrane"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0.15,
+          "looting_multiplier": 0.02
         }
       ]
     },

--- a/src/main/resources/data/changed/loot_tables/entities/latex_pink_wyvern.json
+++ b/src/main/resources/data/changed/loot_tables/entities/latex_pink_wyvern.json
@@ -36,26 +36,17 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 0.0,
-                "max": 1.0
-              },
-              "add": false
-            },
-            {
-              "function": "minecraft:looting_enchant",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 0.0,
-                "max": 1.0
-              }
-            }
-          ],
           "name": "minecraft:phantom_membrane"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0.1,
+          "looting_multiplier": 0.02
         }
       ]
     },

--- a/src/main/resources/data/changed/loot_tables/entities/latex_pink_yuin_dragon.json
+++ b/src/main/resources/data/changed/loot_tables/entities/latex_pink_yuin_dragon.json
@@ -13,35 +13,6 @@
               "count": {
                 "type": "minecraft:uniform",
                 "min": 0.0,
-                "max": 2.0
-              },
-              "add": false
-            },
-            {
-              "function": "minecraft:looting_enchant",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 0.0,
-                "max": 1.0
-              }
-            }
-          ],
-          "name": "minecraft:phantom_membrane"
-        }
-      ]
-    },
-    {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
-      "entries": [
-        {
-          "type": "minecraft:item",
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 0.0,
                 "max": 1.0
               },
               "add": false
@@ -65,6 +36,26 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "name": "minecraft:phantom_membrane"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0.15,
+          "looting_multiplier": 0.02
+        }
+      ]
+    },
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
           "name": "changed:pink_pants"
         },
         {
@@ -78,7 +69,7 @@
         },
         {
           "condition": "minecraft:random_chance_with_looting",
-          "chance": 0.025,
+          "chance": 0.05,
           "looting_multiplier": 0.01
         }
       ]

--- a/src/main/resources/data/changed/loot_tables/entities/latex_red_dragon.json
+++ b/src/main/resources/data/changed/loot_tables/entities/latex_red_dragon.json
@@ -26,35 +26,6 @@
               }
             }
           ],
-          "name": "minecraft:phantom_membrane"
-        }
-      ]
-    },
-    {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
-      "entries": [
-        {
-          "type": "minecraft:item",
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 0.0,
-                "max": 2.0
-              },
-              "add": false
-            },
-            {
-              "function": "minecraft:looting_enchant",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 0.0,
-                "max": 1.0
-              }
-            }
-          ],
           "name": "minecraft:red_sand"
         }
       ]
@@ -85,6 +56,26 @@
             }
           ],
           "name": "minecraft:red_dye"
+        }
+      ]
+    },
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:phantom_membrane"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0.15,
+          "looting_multiplier": 0.02
         }
       ]
     }

--- a/src/main/resources/data/changed/recipes/black_dye_from_latex_inkball.json
+++ b/src/main/resources/data/changed/recipes/black_dye_from_latex_inkball.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "changed:latex_inkball"
+    }
+  ],
+  "result": {
+    "item": "minecraft:black_dye"
+  }
+}


### PR DESCRIPTION
- Allowed black dye to be crafted from latex inkballs

People suggested the drop rate was too high for phantom membranes, an item with not many uses.