### PR TITLE
Updated lang, Added some additional properties to a few blocks.

### DIFF
--- a/src/main/java/net/ltxprogrammer/changed/ChangedConfig.java
+++ b/src/main/java/net/ltxprogrammer/changed/ChangedConfig.java
@@ -81,7 +81,7 @@ public class ChangedConfig {
             builder.comment("Got a lot of mods? Unique model generation will be limited to minecraft and changed");
             fastAndCheapLatexBlocks = builder.define("fastAndCheapLatexBlocks", false);
             builder.comment("Specify the location of the transfur meter");
-            transfurMeterPosition = builder.defineEnum("transfurMeterPosition", TransfurProgressOverlay.Position.HOTBAR_LEFT);
+            transfurMeterPosition = builder.defineEnum("transfurMeterPosition", TransfurProgressOverlay.Position.BOTTOM_LEFT);
         }
 
         @Override

--- a/src/main/java/net/ltxprogrammer/changed/block/CardboardBoxSmall.java
+++ b/src/main/java/net/ltxprogrammer/changed/block/CardboardBoxSmall.java
@@ -15,6 +15,7 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -46,6 +47,10 @@ public class CardboardBoxSmall extends Block implements EntityBlock, SimpleWater
 
     public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         return SHAPE;
+    }
+
+    public boolean canSurvive(BlockState p_52783_, LevelReader p_52784_, BlockPos p_52785_) {
+        return p_52784_.getBlockState(p_52785_.below()).isFaceSturdy(p_52784_, p_52785_.below(), Direction.UP);
     }
 
     public VoxelShape getOcclusionShape(BlockState state, BlockGetter level, BlockPos pos) {

--- a/src/main/java/net/ltxprogrammer/changed/block/DroppedOrange.java
+++ b/src/main/java/net/ltxprogrammer/changed/block/DroppedOrange.java
@@ -6,11 +6,13 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -52,6 +54,16 @@ public class DroppedOrange extends Block implements NonLatexCoverableBlock, Simp
     @Override
     public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
         return List.of(new ItemStack(ChangedItems.ORANGE.get(), state.getValue(ORANGES)));
+    }
+
+    @Override
+    public void neighborChanged(BlockState blockState, Level level, BlockPos blockPos, Block source, BlockPos sourcePos, boolean simulate) {
+        super.neighborChanged(blockState, level, blockPos, source, sourcePos, simulate);
+        if (!blockState.canSurvive(level, blockPos)) {
+            BlockEntity blockentity = blockState.hasBlockEntity() ? level.getBlockEntity(blockPos) : null;
+            dropResources(blockState, level, blockPos, blockentity);
+            level.removeBlock(blockPos, false);
+        }
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/block/DroppedSyringe.java
+++ b/src/main/java/net/ltxprogrammer/changed/block/DroppedSyringe.java
@@ -15,6 +15,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -22,24 +23,23 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
-import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Material;
-import net.minecraft.world.level.material.MaterialColor;
-import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.level.material.*;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
-public class DroppedSyringe extends Block implements EntityBlock, NonLatexCoverableBlock {
+public class DroppedSyringe extends Block implements EntityBlock, NonLatexCoverableBlock, SimpleWaterloggedBlock {
     public static final IntegerProperty ROTATION = BlockStateProperties.ROTATION_16;
+    public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
     protected static final VoxelShape SHAPE = Block.box(3.0D, 0.0D, 3.0D, 13.0D, 2.0D, 13.0D);
 
     public DroppedSyringe() {
         super(BlockBehaviour.Properties.of(Material.BUILDABLE_GLASS, MaterialColor.COLOR_LIGHT_GRAY).sound(SoundType.CANDLE).instabreak());
-        this.registerDefaultState(this.stateDefinition.any().setValue(ROTATION, 0));
+        this.registerDefaultState(this.stateDefinition.any().setValue(ROTATION, 0).setValue(WATERLOGGED, false));
     }
 
     public void entityInside(BlockState state, Level level, BlockPos pos, Entity entity) {
@@ -51,16 +51,42 @@ public class DroppedSyringe extends Block implements EntityBlock, NonLatexCovera
         }
     }
 
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        builder.add(ROTATION, WATERLOGGED);
+    }
+
+    @Override
     public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         return SHAPE;
     }
 
+    @Override
+    public void neighborChanged(BlockState blockState, Level level, BlockPos pos, Block source, BlockPos sourcePos, boolean simulate) {
+        super.neighborChanged(blockState, level, pos, source, sourcePos, simulate);
+        if (!blockState.canSurvive(level, pos)) {
+            BlockEntity blockentity = blockState.hasBlockEntity() ? level.getBlockEntity(pos) : null;
+            dropResources(blockState, level, pos, blockentity);
+            level.getBlockEntity(pos, ChangedBlockEntities.DROPPED_SYRINGE.get()).ifPresent(droppedSyringeBlockEntity -> {
+                popResource(level, pos, droppedSyringeBlockEntity.getSyringe());
+                level.removeBlock(pos, false);
+            });
+        }
+    }
+
+    @Override
     public boolean canSurvive(BlockState p_52783_, LevelReader p_52784_, BlockPos p_52785_) {
         return p_52784_.getBlockState(p_52785_.below()).isFaceSturdy(p_52784_, p_52785_.below(), Direction.UP);
     }
 
+    @Override
     public VoxelShape getOcclusionShape(BlockState state, BlockGetter level, BlockPos pos) {
         return Shapes.empty();
+    }
+
+    @Override
+    public RenderShape getRenderShape(BlockState p_54559_) {
+        return super.getRenderShape(p_54559_);
     }
 
     @Override
@@ -85,20 +111,33 @@ public class DroppedSyringe extends Block implements EntityBlock, NonLatexCovera
         return new DroppedSyringeBlockEntity(pos, state);
     }
 
+    @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
         return this.defaultBlockState().setValue(ROTATION, Mth.floor((double) (context.getRotation() * 16.0F / 360.0F) + 0.5D) & 15);
     }
 
+    @Override
     public BlockState rotate(BlockState state, Rotation rotation) {
         return state.setValue(ROTATION, rotation.rotate(state.getValue(ROTATION), 16));
     }
 
+    @Override
     public BlockState mirror(BlockState state, Mirror mirror) {
         return state.setValue(ROTATION, mirror.mirror(state.getValue(ROTATION), 16));
     }
 
-    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
-        builder.add(ROTATION);
+    @Override
+    public FluidState getFluidState(BlockState state) {
+        return state.getValue(WATERLOGGED) ? Fluids.WATER.getSource(false) : super.getFluidState(state);
+    }
+
+    @Override
+    public BlockState updateShape(BlockState state, Direction direction, BlockState otherState, LevelAccessor level, BlockPos pos, BlockPos otherPos) {
+        if (state.getValue(WATERLOGGED)) {
+            level.scheduleTick(pos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
+        }
+
+        return super.updateShape(state, direction, otherState, level, pos, otherPos);
     }
 
     @Override

--- a/src/main/java/net/ltxprogrammer/changed/block/RoombaCharger.java
+++ b/src/main/java/net/ltxprogrammer/changed/block/RoombaCharger.java
@@ -15,6 +15,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -63,6 +64,11 @@ public class RoombaCharger extends AbstractCustomShapeBlock implements IRobotCha
     @Override
     public VoxelShape getShape(BlockState p_60555_, BlockGetter p_60556_, BlockPos p_60557_, CollisionContext p_60558_) {
         return SHAPE;
+    }
+
+    @Override
+    public boolean canSurvive(BlockState p_52783_, LevelReader p_52784_, BlockPos p_52785_) {
+        return p_52784_.getBlockState(p_52785_.below()).isFaceSturdy(p_52784_, p_52785_.below(), Direction.UP);
     }
 
     @Override

--- a/src/main/resources/assets/changed/lang/no_no.json
+++ b/src/main/resources/assets/changed/lang/no_no.json
@@ -168,7 +168,7 @@
   "gamerule.changed:doPale": "Er Pale aktivert",
 
   "key.changed.variant_ability": "Aktiv variantevne",
-  "key.changed.use_ability": "Bruke variantevne",
+  "key.changed.use_ability": "Bruk variantevne",
   "key.changed.extra_jump": "Ekstra hopp",
 
   "container.changed.extra_hands": "Ekstra hendermeny",
@@ -553,9 +553,12 @@
   "changed:advancements.main.kill_all_latex.title": "Gått berserk",
   "changed:advancements.main.kill_all_latex.description": "Drep et av hvert slag av lateksdyr",
 
+  "changed:advancements.main.flying.title": "Sprer dine vinger",
+  "changed:advancements.main.flying.description": "Bruk din flygeevner i 15 sekunder",
+
   "changed.tutorial.select_ability.title": "Velge din evne",
   "changed.tutorial.select_ability.description": "Trykk på %s",
-  "changed.tutorial.use_ability.title": "Bruke din evne",
+  "changed.tutorial.use_ability.title": "Bruk din evne",
   "changed.tutorial.use_ability.description": "Trykk på eller hold %s",
 
   "facility.zone.red_zone": "Rød sone",

--- a/src/main/resources/assets/changed/lang/sv_se.json
+++ b/src/main/resources/assets/changed/lang/sv_se.json
@@ -553,9 +553,12 @@
   "changed:advancements.main.kill_all_latex.title": "Blivit bärsärk",
   "changed:advancements.main.kill_all_latex.description": "Döda en av varje slags av latexdjur",
 
+  "changed:advancements.main.flying.title": "Sprider dina vingar",
+  "changed:advancements.main.flying.description": "Använd din flygförmågor i 15 sekunder",
+
   "changed.tutorial.select_ability.title": "Välj din förmåga",
   "changed.tutorial.select_ability.description": "Tryck %s",
-  "changed.tutorial.use_ability.title": "Använda din förmåga",
+  "changed.tutorial.use_ability.title": "Använd din förmåga",
   "changed.tutorial.use_ability.description": "Tryck eller håll ned %s",
 
   "facility.zone.red_zone": "Röd zon",


### PR DESCRIPTION

- Added missing entries to no_no and sv_se.json.
- Set the TF meter default placement back to what it was before.
 - Made dropped syringe block waterloggable and break when block below is broken.
 - Made dropped oranges block break when block below is broken.
 - Fixed small cardboard boxes and roomba chargers being placeable on top of each other